### PR TITLE
EB 배포 502 오류 수정 - nginx 프록시 포트를 컨테이너 3000으로 변경

### DIFF
--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -5,7 +5,7 @@
   },
   "Ports": [
     {
-      "ContainerPort": 80,
+      "ContainerPort": 3000,
       "HostPort": 80
     }
   ],

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -25,6 +25,5 @@ RUN ln -snf /usr/share/zoneinfo/Asia/Seoul /etc/localtime && \
     echo "Asia/Seoul" > /etc/timezone
 
 EXPOSE 3000
-EXPOSE 80
 
 CMD ["sh", "-c", "rm -f .env && node dist/scripts/generateEnv.js && node dist/src/main"]


### PR DESCRIPTION
## 설명

EB 배포 시 nginx가 Docker 컨테이너의 포트 80으로 프록시했으나, NestJS 앱은 포트 3000에서만 리스닝하고 있어 502 Bad Gateway가 발생하는 문제를 수정합니다.

## 목표

- `Dockerrun.aws.json`의 ContainerPort를 80에서 3000으로 수정하여 EB nginx가 올바른 포트로 프록시하도록 변경
- `apps/api/Dockerfile`에서 불필요한 `EXPOSE 80` 제거

## 변경사항

- [x] `Dockerrun.aws.json`: ContainerPort 80 → 3000
- [x] `apps/api/Dockerfile`: 불필요한 `EXPOSE 80` 제거 (앱은 3000만 사용)

## 목표가 아닌 것 (생략 가능)

앱의 실제 포트 변경 없음. NestJS 앱은 기존과 동일하게 3000 포트 사용.

---

Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>