### PR TITLE
로컬 개발 환경 DB SSL 설정 명시적 비활성화

### DIFF
--- a/apps/api/config/localdev.js
+++ b/apps/api/config/localdev.js
@@ -10,6 +10,7 @@ module.exports = {
       password: 'postgres',
       database: 'readly',
       migrationsRun: true,
+      ssl: undefined,
     },
   },
 


### PR DESCRIPTION
## 설명

로컬 개발 환경(`localdev.js`)의 PostgreSQL 연결 설정에서 `ssl: undefined`를 명시적으로 추가합니다.

## 목표

- 로컬 개발 환경에서 PostgreSQL SSL 연결 시도를 명시적으로 비활성화
- 배포 환경(Elastic Beanstalk)에서는 SSL을 활성화하지만, 로컬 환경에서는 불필요한 SSL 연결로 인한 오류를 방지

## 변경사항

- [x] `apps/api/config/localdev.js`: database 설정에 `ssl: undefined` 추가

## 목표가 아닌 것 (생략 가능)

- `test.js` 등 다른 환경 설정 파일은 변경하지 않음 (별도 검토 필요)

---

Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>