### PR TITLE
JWT user refresh token secret 환경변수 오타 수정

### DIFF
--- a/apps/api/config/default.js
+++ b/apps/api/config/default.js
@@ -34,7 +34,7 @@ module.exports = {
           expiresIn: '1h',
         },
         refresh: {
-          secret: process.env.JWT_USER_ACCESS_SECRET,
+          secret: process.env.JWT_USER_REFRESH_SECRET,
           expiresIn: '7d',
         }
       }


### PR DESCRIPTION
## Summary

EB 환경에서 user.login 호출 시 `secretOrPrivateKey must have a value` 에러가 발생하던 문제를 수정합니다.

## Why (의도)

Elastic Beanstalk 배포 환경에서 로그인이 불가능한 상태였습니다. refresh token 서명에 잘못된 환경변수를 참조하고 있어 secret 값이 undefined로 평가되었습니다.

## What (문제)

`apps/api/config/default.js`의 JWT refresh token 설정에서 secret 환경변수가 `JWT_USER_ACCESS_SECRET`(오타)로 잘못 지정되어 있었습니다. 해당 값이 undefined로 평가되면서 JWT 서명 시 `secretOrPrivateKey must have a value` 에러가 발생했습니다.

## How (해결 방법)

`config/default.js` line 37의 refresh token secret 환경변수를 `JWT_USER_ACCESS_SECRET`에서 올바른 값인 `JWT_USER_REFRESH_SECRET`으로 수정했습니다.

## 주요 변경사항

### JWT refresh token secret 환경변수 오타 수정
**파일:** `apps/api/config/default.js`
- `process.env.JWT_USER_ACCESS_SECRET` → `process.env.JWT_USER_REFRESH_SECRET`

## 사이드 이펙트

| 영향 받는 영역 | 영향 내용 | 위험도 |
|---------------|----------|--------|
| 기존 refresh token | 기존에 발급된 refresh token은 다른 secret으로 서명되어 있어 재로그인 필요 | 낮음 |

## 변경 흐름

```mermaid
graph LR
  A[config/default.js] --> B[JWT refresh token 서명]
  B --> C[user.login 정상 동작]
```

Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>