### PR TITLE
API 배포 워크플로우에 paths-ignore 추가

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'apps/client/**'
+      - '.claude/**'
 
 env:
   AWS_REGION: ap-northeast-2


### PR DESCRIPTION
## 설명

`deploy-api.yml`에 `paths-ignore`를 추가하여 API와 무관한 파일 변경 시 불필요한 API 배포가 트리거되지 않도록 합니다.

## 목표

- 클라이언트 코드(`apps/client/**`) 변경 시 API 배포 스킵
- Claude 설정 파일(`.claude/**`) 변경 시 API 배포 스킵

## 변경사항

- [x] `.github/workflows/deploy-api.yml`에 `paths-ignore` 규칙 추가
  - `apps/client/**` 경로 무시
  - `.claude/**` 경로 무시

## 목표가 아닌 것 (생략 가능)

- 클라이언트 배포 워크플로우 변경은 이 PR에 포함하지 않습니다

Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>