### PR TITLE
FIX: BookstoreForm defaultValue 타입에 null 허용 추가

### DIFF
--- a/apps/client/src/components/bookstore/BookstoreForm.tsx
+++ b/apps/client/src/components/bookstore/BookstoreForm.tsx
@@ -33,8 +33,8 @@ export interface BookstoreFormProps {
   defaultValue?: {
     penName?: string;
     storeName?: string;
-    bio?: string;
-    profileImage?: string;
+    bio?: string | null;
+    profileImage?: string | null;
   };
   onSubmit: (data: BookstoreFormData) => void;
   isPending?: boolean;


### PR DESCRIPTION
## Summary

- `BookstoreFormProps.defaultValue`의 `bio`, `profileImage` 필드에 `null` 타입 추가
- API 반환 타입(`string | null`)과 Props 타입(`string | undefined`) 불일치로 인한 tsc strict 모드 에러 수정
- plan/editor PR (#139) CI Build Client 빌드 실패 해결

## 원인

`bookstore.getMyBookstore` API가 `bio: string | null`, `profileImage: string | null`을 반환하는데,
`BookstoreFormProps.defaultValue`가 `bio?: string`, `profileImage?: string`만 허용하여
`profile.tsx`에서 직접 전달 시 타입 에러 발생.

## 변경 사항

`apps/client/src/components/bookstore/BookstoreForm.tsx`
- `bio?: string` → `bio?: string | null`
- `profileImage?: string` → `profileImage?: string | null`

## Test plan

- [ ] Build Client CI 통과 확인
- [ ] plan/editor PR (#139) CI 재실행 시 빌드 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)