### PR TITLE
Client 자동 배포에 production 환경 추가

### DIFF
--- a/.github/workflows/deploy-client.yml
+++ b/.github/workflows/deploy-client.yml
@@ -98,11 +98,26 @@ jobs:
             --distribution-id ${{ vars.CF_DISTRIBUTION_DEV }} \
             --paths "/*"
 
+      # --- AUTO DEPLOY TO PRODUCTION (start) ---
+      # 현재 운영 환경을 사용하지 않아 dev 배포 후 자동으로 production에도 배포.
+      # 운영 전환 시 이 블록(start~end)을 삭제하면 수동 배포(workflow_dispatch)로 원복됨.
+      - name: Deploy to production (auto)
+        run: |
+          aws s3 rm s3://${{ env.S3_BUCKET }}/production/ --recursive
+          aws s3 cp s3://${{ env.S3_BUCKET }}/build/${{ steps.hash.outputs.short }}/ s3://${{ env.S3_BUCKET }}/production/ --recursive
+
+      - name: Invalidate CloudFront cache (production)
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id ${{ vars.CF_DISTRIBUTION_PROD }} \
+            --paths "/*"
+      # --- AUTO DEPLOY TO PRODUCTION (end) ---
       - name: Summary
         run: |
-          echo "### Deploy Client (Dev) :rocket:" >> $GITHUB_STEP_SUMMARY
+          echo "### Deploy Client :rocket:" >> $GITHUB_STEP_SUMMARY
           echo "- **Build**: \`${{ steps.hash.outputs.short }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **S3**: \`s3://${{ env.S3_BUCKET }}/develop/\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Dev**: \`s3://${{ env.S3_BUCKET }}/develop/\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Production**: \`s3://${{ env.S3_BUCKET }}/production/\` (auto)" >> $GITHUB_STEP_SUMMARY
 
   deploy-production:
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'deploy-production'


### PR DESCRIPTION
## 📋 Summary

dev 배포 시 production에도 자동으로 배포하도록 변경. 기존 수동 배포(workflow_dispatch)는 그대로 유지.

## 🎯 Why (의도)

현재 production 환경을 별도로 운영하지 않아, dev 배포와 production 배포를 매번 수동으로 분리 실행하는 비효율이 발생함. 자동화로 배포 오버헤드를 제거하고 dev/production 동기화를 보장.

## 🐛 What (문제)

dev 배포 후 수동으로 `workflow_dispatch`를 통해 production 배포를 별도 실행해야 했으나, 운영하지 않는 환경에서 이 절차가 불필요한 수동 작업으로 남아 있음.

## 🔧 How (해결 방법)

`build-and-deploy-dev` job 내 Invalidate CloudFront (dev) 이후에 production 자동 배포 step을 추가. 주석 블록으로 감싸두어 운영 전환 시 블록 삭제만으로 수동 배포 원복 가능.

## 🔄 주요 변경사항

### production 자동 배포 step 추가

- S3 production 폴더 동기화 (develop 빌드 결과를 production에 복사)
- CloudFront production 캐시 무효화
- 관련 파일: `.github/workflows/deploy-client.yml`

### Summary step 업데이트

- Dev/Production 배포 URL 모두 출력하도록 변경

## ⚠️ 사이드 이펙트

| 영향 받는 영역 | 영향 내용 | 위험도 |
| --- | --- | --- |
| Production 환경 | develop 브랜치 push 시마다 production 자동 배포 | 낮음 (의도된 동작) |

## 🔀 변경 흐름

```mermaid
graph LR
  A[develop push] --> B[Build]
  B --> C[Deploy Dev]
  C --> D[Deploy Production - auto]
  D --> E[Summary]
```

---

> 원복 방법: `deploy-client.yml`에서 `AUTO DEPLOY TO PRODUCTION (start)` ~ `(end)` 주석 블록 삭제 시 기존 수동 배포로 복귀

Generated with [Claude Code](https://claude.ai/code)