### PR TITLE
S3 업로드 객체 public-read 설정 수정

### DIFF
--- a/apps/api/src/module/upload/upload.service.ts
+++ b/apps/api/src/module/upload/upload.service.ts
@@ -30,6 +30,7 @@ export class UploadService {
       Bucket: this.bucket,
       Key: key,
       ContentType: contentType,
+      ACL: 'public-read',
     });
 
     return getSignedUrl(this.s3Client, command, {
@@ -39,7 +40,8 @@ export class UploadService {
         presignedUrl,
         cdnUrl: `${this.cdnUrl}/${key}`,
       }))
-      .catch(() => {
+      .catch((error: unknown) => {
+        console.error('S3 presigned URL generation failed:', error);
         throw new TRPCError({
           code: 'INTERNAL_SERVER_ERROR',
           message: 'Failed to generate presigned URL',


### PR DESCRIPTION
## 설명

업로드된 S3 객체가 public read로 설정되지 않아 외부에서 접근이 불가능한 문제를 수정합니다.
presigned URL 생성 실패 시 에러 로깅도 함께 추가합니다.

## 목표

- S3 PutObjectCommand에 `ACL: 'public-read'` 옵션 추가로 업로드 파일을 공개 접근 가능하게 설정
- presigned URL 생성 실패 시 원본 에러를 `console.error`로 로깅하여 디버깅 용이성 향상
- catch 파라미터에 `unknown` 타입 명시로 타입 안전성 강화

## 변경사항

- [x] `apps/api/src/module/upload/upload.service.ts` — PutObjectCommand에 `ACL: 'public-read'` 추가
- [x] `apps/api/src/module/upload/upload.service.ts` — catch 블록에 `console.error` 에러 로깅 추가
- [x] `apps/api/src/module/upload/upload.service.ts` — catch 파라미터 타입을 `unknown`으로 명시

## 목표가 아닌 것 (생략 가능)

- S3 버킷 설정 변경 (인프라 작업 별도 필요)
  - S3 버킷의 Object Ownership이 "Bucket owner preferred"이어야 ACL이 동작합니다
  - S3 버킷의 Block Public Access에서 ACL 관련 설정(`BlockPublicAcls`, `IgnorePublicAcls`)이 비활성화되어 있어야 합니다

Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>