### PR TITLE
발행 시 빈 제목/내용 검증 추가

### DIFF
--- a/apps/api/src/module/post/post.service.ts
+++ b/apps/api/src/module/post/post.service.ts
@@ -2,6 +2,7 @@ import {
   Injectable,
   NotFoundException,
   ForbiddenException,
+  BadRequestException,
 } from '@nestjs/common';
 import { In } from 'typeorm';
 import { RepositoryProvider } from '../shared/transaction/repository.provider';
@@ -247,6 +248,16 @@ export class PostService {
 
     if (!latest) {
       throw new NotFoundException('No version found for this post');
+    }
+
+    // 빈 제목/내용 검증
+    if (latest.title.trim() === '') {
+      throw new BadRequestException('제목을 입력해주세요');
+    }
+
+    const textContent = latest.freeContent.replace(/<[^>]*>/g, '').trim();
+    if (textContent === '') {
+      throw new BadRequestException('내용을 입력해주세요');
     }
 
     // 발행 시 메타데이터 업데이트

--- a/apps/api/src/module/post/post.service.ts
+++ b/apps/api/src/module/post/post.service.ts
@@ -255,7 +255,12 @@ export class PostService {
       throw new BadRequestException('제목을 입력해주세요');
     }
 
-    const textContent = latest.freeContent.replace(/<[^>]*>/g, '').trim();
+    const textContent = latest.freeContent
+      .replace(/<[^>]*>/g, '')
+      .replace(/&nbsp;/g, ' ')
+      .replace(/&#\d+;/g, '')
+      .replace(/&\w+;/g, '')
+      .trim();
     if (textContent === '') {
       throw new BadRequestException('내용을 입력해주세요');
     }

--- a/apps/client/src/components/posts/manage/PostActions.tsx
+++ b/apps/client/src/components/posts/manage/PostActions.tsx
@@ -19,8 +19,10 @@ interface PostActionsProps {
   status: PostStatus;
   publishDefaults?: Partial<PublishSheetResult>;
   isRepublish?: boolean;
+  canPublish?: boolean;
   onEdit: () => void;
   onPublish: (options: PublishOptions) => void;
+  onPublishBlocked?: () => void;
   onUnpublish: () => void;
   onDelete: () => void;
 }
@@ -29,8 +31,10 @@ const PostActions = ({
   status,
   publishDefaults,
   isRepublish,
+  canPublish = true,
   onEdit,
   onPublish,
+  onPublishBlocked,
   onUnpublish,
   onDelete,
 }: PostActionsProps) => {
@@ -57,6 +61,8 @@ const PostActions = ({
     handleClose();
     if (status === 'published') {
       onUnpublish();
+    } else if (!canPublish) {
+      onPublishBlocked?.();
     } else {
       SnappyModal.show(
         <PublishSheet

--- a/apps/client/src/components/posts/manage/PostListItem.tsx
+++ b/apps/client/src/components/posts/manage/PostListItem.tsx
@@ -1,4 +1,5 @@
 import { FileText } from 'lucide-react';
+import SnappyModal from 'react-snappy-modal';
 import tw from 'tailwind-styled-components';
 
 import PostAccessBadge from '@/components/posts/manage/PostAccessBadge';
@@ -7,6 +8,7 @@ import PostActions, {
 } from '@/components/posts/manage/PostActions';
 import PostStatusBadge from '@/components/posts/manage/PostStatusBadge';
 import { PostItem } from '@/components/posts/manage/types';
+import { AlertModal } from '@/shared/modal/AlertModal';
 
 interface BookstoreDefaults {
   defaultAccessLevel: 'public' | 'subscriber' | 'purchaser';
@@ -55,6 +57,13 @@ const PostListItem = ({
   const dateLabel = post.status === 'published' ? '발행' : '저장';
 
   const isDraft = post.status === 'draft';
+  const canPublish = !!post.title.trim();
+
+  const handlePublishBlocked = () => {
+    SnappyModal.show(
+      <AlertModal title="발행할 수 없습니다" message="제목을 입력해주세요." />,
+    );
+  };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' || e.key === ' ') {
@@ -122,8 +131,10 @@ const PostListItem = ({
                 }
           }
           isRepublish={post.status === 'published'}
+          canPublish={canPublish}
           onEdit={() => onEdit(post.id)}
           onPublish={(options) => onPublish(post.id, options)}
+          onPublishBlocked={handlePublishBlocked}
           onUnpublish={() => onUnpublish(post.id)}
           onDelete={() => onDelete(post.id)}
         />

--- a/apps/client/src/components/posts/manage/PostListItem.tsx
+++ b/apps/client/src/components/posts/manage/PostListItem.tsx
@@ -57,11 +57,14 @@ const PostListItem = ({
   const dateLabel = post.status === 'published' ? '발행' : '저장';
 
   const isDraft = post.status === 'draft';
-  const canPublish = !!post.title.trim();
+  const canPublish = isDraft ? !!post.title.trim() : true;
 
   const handlePublishBlocked = () => {
     SnappyModal.show(
-      <AlertModal title="발행할 수 없습니다" message="제목을 입력해주세요." />,
+      <AlertModal
+        title="발행할 수 없습니다"
+        message="제목과 내용을 입력한 후 발행해주세요."
+      />,
     );
   };
 


### PR DESCRIPTION
## 설명

빈 draft 생성이 가능해지면서 제목/내용 없이 발행이 가능해진 문제를 BE/FE 양측에서 방어합니다.

Closes #159

## 목표

- **BE**: `publishPost()`에서 빈 제목/내용을 서버 측에서 검증하여 `BadRequestException` 반환
- **FE**: 발행 버튼 클릭 시 사전 검증으로 `AlertModal`을 통해 사용자에게 안내

## 변경사항

- [x] `apps/api/src/module/post/post.service.ts` — `publishPost()`에 빈 제목/내용 검증 추가 (`BadRequestException`)
- [x] `apps/client/src/components/posts/manage/PostActions.tsx` — `canPublish`/`onPublishBlocked` props 추가, 발행 전 gate 처리
- [x] `apps/client/src/components/posts/manage/PostListItem.tsx` — `canPublish` 계산 로직, `AlertModal`로 검증 실패 안내

## 목표가 아닌 것 (생략 가능)

- 내용(freeContent) 검증은 FE에서 별도로 처리하지 않음 — BE에서 HTML 태그 제거 후 텍스트 기준으로 검증하므로 서버 측에서 충분히 방어됨
- 발행 버튼 비활성화 UI는 이번 범위에 포함하지 않음