### PR TITLE
Post 저장/수정 mutation에 tRPC 캐시 무효화 추가

### DIFF
--- a/apps/client/src/hooks/useAutoSave.ts
+++ b/apps/client/src/hooks/useAutoSave.ts
@@ -44,6 +44,7 @@ export const useAutoSave = ({
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isMountedRef = useRef(true);
 
+  const utils = trpc.useUtils();
   const saveDraftMutation = trpc.post.saveDraft.useMutation();
 
   const isDirty = useCallback((): boolean => {
@@ -76,11 +77,13 @@ export const useAutoSave = ({
           saveType,
         },
         {
-          onSuccess: () => {
+          onSuccess: (response) => {
             if (!isMountedRef.current) return;
             prevRef.current = payload;
             setSaveStatus('saved');
             setLastSavedAt(new Date());
+            utils.post.getOne.setData({ postId }, response);
+            utils.post.getMy.invalidate();
           },
           onError: () => {
             if (!isMountedRef.current) return;
@@ -97,6 +100,7 @@ export const useAutoSave = ({
       isDirty,
       clearTimer,
       saveDraftMutation,
+      utils,
     ],
   );
 

--- a/apps/client/src/routes/_auth/my-bookstore/posts/$postId.edit.tsx
+++ b/apps/client/src/routes/_auth/my-bookstore/posts/$postId.edit.tsx
@@ -16,6 +16,7 @@ function WritePage() {
   const navigate = Route.useNavigate();
 
   const { data: post, isLoading } = trpc.post.getOne.useQuery({ postId });
+  const utils = trpc.useUtils();
 
   const [title, setTitle] = useState('');
   const [freeContent, setFreeContent] = useState('');
@@ -39,6 +40,9 @@ function WritePage() {
   });
 
   const deleteMutation = trpc.post.delete.useMutation({
+    onSuccess: () => {
+      utils.post.getMy.invalidate();
+    },
     onError: (error) => {
       console.error('Draft 삭제 실패:', error.message);
     },

--- a/apps/client/src/routes/_auth/my-bookstore/posts/index.tsx
+++ b/apps/client/src/routes/_auth/my-bookstore/posts/index.tsx
@@ -43,8 +43,9 @@ function PostsPage() {
   });
 
   const publishMutation = trpc.post.publish.useMutation({
-    onSuccess: () => {
+    onSuccess: (_data, variables) => {
       utils.post.getMy.invalidate();
+      utils.post.getOne.invalidate({ postId: variables.postId });
       toast.success('포스트가 발행되었습니다');
     },
     onError: (error) => {
@@ -55,7 +56,10 @@ function PostsPage() {
   });
 
   const unpublishMutation = trpc.post.unpublish.useMutation({
-    onSuccess: () => utils.post.getMy.invalidate(),
+    onSuccess: (_data, variables) => {
+      utils.post.getMy.invalidate();
+      utils.post.getOne.invalidate({ postId: variables.postId });
+    },
     onError: (error) => {
       SnappyModal.show(
         <AlertModal title="발행 취소 실패" message={error.message} />,


### PR DESCRIPTION
## 설명

Post 저장/수정 시 tRPC 캐시를 즉시 갱신하여 저장 후 목록 이동 또는 재진입 시 발생하는 stale 데이터 딜레이를 제거합니다.

## 목표

- `saveDraft` / `publish` / `unpublish` / `delete` mutation의 `onSuccess`에서 관련 tRPC 캐시를 즉시 무효화 또는 교체
- GH#67 원본 콘텐츠 유실 버그 수정(PR #193) 이후 남아 있던 UX 딜레이 해소

### Why (의도)

PR #193으로 원본 콘텐츠 유실 버그를 수정한 뒤에도 두 가지 UX 이슈가 남아 있었습니다.

1. 저장 후 목록으로 이동하면 이전 제목이 잠깐 보였다가 refetch 완료 후 업데이트됨
2. 저장 후 동일 post에 재진입하면 이전 내용이 잠깐 보였다가 refetch 완료 후 업데이트됨

mutation 성공 시점에 tRPC 캐시를 갱신하지 않아 stale 데이터가 잠깐 표시되는 것이 원인이었습니다.

### What (문제)

`saveDraft` 등의 mutation `onSuccess` 콜백에서 `getOne` / `getMy` 캐시를 갱신하지 않아, mutation 완료 후에도 화면에 이전 데이터가 잠시 남아 있었습니다.

### How (해결 방법)

각 mutation의 `onSuccess`에서 아래 두 가지 방식으로 캐시를 즉시 갱신합니다.

- `setData` — 서버 응답값으로 `getOne` 캐시를 즉시 교체 (재요청 없이 최신화)
- `invalidate` — `getMy` / `getOne` 쿼리를 무효화하여 background refetch 유도

## 변경사항

- [x] `useAutoSave` — `saveDraft.onSuccess`에서 `getOne.setData(postId, response)` + `getMy.invalidate()` 호출. 편집 페이지 재진입 시 딜레이 제거.
- [x] `$postId.edit.tsx` — 빈 draft 자동 삭제 경로(`delete.onSuccess`)에서 `getMy.invalidate()` 호출. 삭제 후 목록에서 즉시 사라짐.
- [x] `posts/index.tsx` — `publish`/`unpublish` mutation `onSuccess`에 `getOne.invalidate({ postId: variables.postId })` 추가 (기존 `getMy.invalidate`와 병행).

## 목표가 아닌 것

- Optimistic update 도입 (이번 범위에서 제외, 필요 시 별도 작업)

---

## 검증

Chrome DevTools로 라이브 테스트 완료:
- 제목 수정 → 저장 → 목록 이동: 즉시 새 제목 표시
- 동일 post 재진입: 딜레이 없이 즉시 최신 내용 표시

Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>